### PR TITLE
rest API for django-radio

### DIFF
--- a/radio/apps/api/serializers.py
+++ b/radio/apps/api/serializers.py
@@ -1,0 +1,12 @@
+from apps.programmes.models import Programme
+from rest_framework import serializers
+
+
+class ProgrammeSerializer(serializers.HyperlinkedModelSerializer):
+    url = serializers.HyperlinkedIdentityField(
+        view_name='programmes:detail',
+        lookup_field='slug')
+
+    class Meta:
+        model = Programme
+        fields = ('url', 'name', 'synopsis', 'photo', 'language', 'category')

--- a/radio/apps/api/tests.py
+++ b/radio/apps/api/tests.py
@@ -1,0 +1,36 @@
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+import serializers
+
+
+class TestSerializers(TestCase):
+    def test_programme(self):
+        serializer = serializers.ProgrammeSerializer()
+        self.assertEqual(
+            serializer.fields.keys(),
+            ['url', 'name', 'synopsis', 'photo', 'language', 'category'])
+
+
+class TestAPI(TestCase):
+    client_class = APIClient
+
+    def test_api(self):
+        response = self.client.get('/api/2/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_programmes_get_all(self):
+        response = self.client.get('/api/2/programmes/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_programmes_post(self):
+        response = self.client.post('/api/2/programmes/')
+        self.assertEqual(response.status_code, 405)
+
+    def test_programmes_put(self):
+        response = self.client.put('/api/2/programmes/')
+        self.assertEqual(response.status_code, 405)
+
+    def test_programmes_delete(self):
+        response = self.client.delete('/api/2/programmes/')
+        self.assertEqual(response.status_code, 405)

--- a/radio/apps/api/urls.py
+++ b/radio/apps/api/urls.py
@@ -1,0 +1,13 @@
+from rest_framework import routers
+from django.conf.urls import url, include
+
+import views
+
+
+router = routers.DefaultRouter()
+router.register(r'programmes', views.ProgrammeViewSet)
+
+
+urlpatterns = [
+    url(r'^', include(router.urls))
+]

--- a/radio/apps/api/views.py
+++ b/radio/apps/api/views.py
@@ -1,0 +1,8 @@
+from apps.programmes.models import Programme
+from rest_framework import viewsets
+import serializers
+
+
+class ProgrammeViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Programme.objects.all()
+    serializer_class = serializers.ProgrammeSerializer

--- a/radio/configs/common/urls.py
+++ b/radio/configs/common/urls.py
@@ -75,6 +75,7 @@ urlpatterns = patterns('',
 
     url(r'^api/1/recording_schedules/$', 'apps.radio.views.recording_schedules', name="recording_schedules"),
     url(r'^api/1/submit_recorder/$', 'apps.radio.views.submit_recorder', name="submit_recorder"),
+    url(r'^api/2/', include('apps.api.urls', namespace="api"))
 )
 
 if settings.DEBUG and 'debug_toolbar' in settings.INSTALLED_APPS:


### PR DESCRIPTION
Most radio stations already have a zoo of various software stacks. There are websites based on Wordpress, Joomla, ... To also use django-radio as a scheduling and planing solution, we need some APIs to connect all kind of third party software to a django-radio based backend. (No, we don't want to rely on iframes any longer ;-) )

While there already are some API stubs based on various implementations (some plain Django, some Django-Rest-Framework) mounted in several views, I propose to implement a clean and straightforward REST API based on Django-Rest-Framework within a separate application. To not conflict with existing code I started an url namespace `/api/2/`.

This pull request implements a very basic REST API to list existing programmes. This is only a first starting point, I am going to use this app to implement all other REST APIs I am expecting we need for scheduling or other purposes.

In the long term I propose to also wrap the frontend website in a separate app. This way radio stations could use django-radio as an API-only backend for their existing infrastructure as well as a full featured frontend stack.