### PR TITLE
[#17] Shows radio show as title for podcast if not defined in latest …

### DIFF
--- a/radio/apps/radio/templates/radio/index.html
+++ b/radio/apps/radio/templates/radio/index.html
@@ -148,7 +148,7 @@
                 <div class="hline"></div>
                 {% for episode in latest_episodes %}
                     <p>
-                        <a href="{{ episode.get_absolute_url }}">{% firstof episode.title|title episode|title %}</a>
+                        <a href="{{ episode.get_absolute_url }}">{% firstof episode.title episode %}</a>
                     </p>
                 {% empty %}
                     <p>{% trans "There are currently no podcast" %}</p>


### PR DESCRIPTION
…podcast

This fixed the #17 bug, that is still open in master.

After this change the latest podcast works in home page of radioco. Check patch appied in https://cuacfm.org/radioco/