### PR TITLE
[#32] Fixes warnings for deprecated django uses

### DIFF
--- a/radio/apps/global_settings/templates/global_settings/admin_change_form.html
+++ b/radio/apps/global_settings/templates/global_settings/admin_change_form.html
@@ -1,7 +1,6 @@
 {% extends "admin/change_form.html" %}
 {% load i18n %}
 {% load admin_urls %}
-{% load url from future %}
 
 
 {% block breadcrumbs %}

--- a/radio/apps/global_settings/templates/global_settings/admin_object_history.html
+++ b/radio/apps/global_settings/templates/global_settings/admin_object_history.html
@@ -1,6 +1,5 @@
 {% extends "admin/object_history.html" %}
 {% load i18n %}
-{% load url from future %}
 
 
 {% block breadcrumbs %}

--- a/radio/apps/programmes/migrations/0009_auto_20160325_1519.py
+++ b/radio/apps/programmes/migrations/0009_auto_20160325_1519.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('programmes', '0008_auto_20160116_1509'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='episode',
+            name='people',
+            field=models.ManyToManyField(to=settings.AUTH_USER_MODEL, verbose_name='people', through='programmes.Participant', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='programme',
+            name='announcers',
+            field=models.ManyToManyField(to=settings.AUTH_USER_MODEL, verbose_name='announcers', through='programmes.Role', blank=True),
+        ),
+    ]

--- a/radio/apps/programmes/models.py
+++ b/radio/apps/programmes/models.py
@@ -74,7 +74,7 @@ class Programme(models.Model):
         blank=True, null=True, verbose_name=_('end date'), help_text=_("This field can be null.")
     )
     announcers = models.ManyToManyField(
-        User, blank=True, null=True, through='Role', verbose_name=_("announcers")
+        User, blank=True, through='Role', verbose_name=_("announcers")
     )
     synopsis = RichTextField(blank=True, verbose_name=_("synopsis"))
     photo = models.ImageField(
@@ -149,7 +149,7 @@ class Programme(models.Model):
 
 class Episode(models.Model):
     title = models.CharField(max_length=100, blank=True, null=True, verbose_name=_("title"))
-    people = models.ManyToManyField(User, blank=True, null=True, through='Participant', verbose_name=_("people"))
+    people = models.ManyToManyField(User, blank=True, through='Participant', verbose_name=_("people"))
     programme = models.ForeignKey(Programme, verbose_name=_("programme"))
     summary = RichTextField(blank=True, verbose_name=_("summary"))
     issue_date = models.DateTimeField(blank=True, null=True, db_index=True, verbose_name=_('issue date'))

--- a/radio/configs/common/settings.py
+++ b/radio/configs/common/settings.py
@@ -35,8 +35,6 @@ SECRET_KEY = '(h_$1pj(&usx%kw^m6$7*x9pnar+t_136g!3)g#+eje5r^3(!+'
 
 DEBUG = True
 
-TEMPLATE_DEBUG = True
-
 # Application definition
 INSTALLED_APPS = (
     'django.contrib.auth',
@@ -78,33 +76,26 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.locale.LocaleMiddleware',
 )
 
-TEMPLATE_CONTEXT_PROCESSORS = (
-    'django.contrib.auth.context_processors.auth',
-    'django.core.context_processors.i18n',
-    'django.core.context_processors.media',
-    'django.core.context_processors.static',
-    'django.core.context_processors.tz',
-    'django.core.context_processors.request',
-    'django.contrib.messages.context_processors.messages',
-    'apps.radio.context_processors.settings',
-)
-
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-)
-
-TEMPLATE_DIRS = (
-    os.path.join(SITE_ROOT, 'templates'),
-)
-
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': TEMPLATE_DIRS,
+        'DIRS': [
+	    os.path.join(SITE_ROOT, 'templates'),
+	],
+	'APP_DIRS': True,
         'OPTIONS': {
-            'context_processors': TEMPLATE_CONTEXT_PROCESSORS,
-            'loaders': TEMPLATE_LOADERS,
+            'context_processors': [
+		'apps.radio.context_processors.settings',
+		'django.core.context_processors.request',
+		'django.contrib.auth.context_processors.auth',
+		'django.template.context_processors.debug',
+		'django.core.context_processors.i18n',
+		'django.core.context_processors.media',
+		'django.core.context_processors.static',
+		'django.core.context_processors.tz',
+		'django.contrib.messages.context_processors.messages',
+	    ],
+	    'debug': DEBUG,
         },
     },
 ]


### PR DESCRIPTION
- Fixes warnings for deprecated use of url improrted from future
- Fixed depreceted use of TEMPLATE_\* in newest Django versions
- Fixes warnings related to Null=True in ManyToMany relations
