### PR TITLE
[#30] Fixes participants representation.

### DIFF
--- a/radio/apps/programmes/models.py
+++ b/radio/apps/programmes/models.py
@@ -273,7 +273,7 @@ class Participant(models.Model):
         )
 
     def __unicode__(self):
-        return str(self.episode) + ": " + self.person.username
+        return u"%s: %s" % (self.episode, self.person.username)
 
 
 class Role(models.Model):
@@ -292,7 +292,7 @@ class Role(models.Model):
         )
 
     def __unicode__(self):
-        return self.programme.name + ": " + self.person.username
+        return u"%s: %s" % (self.programme.name, self.person.username)
 
 
 class Podcast(models.Model):


### PR DESCRIPTION
When episode title had a dash, there was an error in the admin
that made imposible to re-edit an episode as participants weren't
shown after first edit including some special caracters.

Same happened with roles in programms but as names of programmes
are never edited problem was never raised.