### PR TITLE
[#17] Improvements in title representation of episodes when not set

### DIFF
--- a/radio/apps/programmes/templates/programmes/episode_detail.html
+++ b/radio/apps/programmes/templates/programmes/episode_detail.html
@@ -14,7 +14,7 @@
             </div>
 
             <div class="col-lg-5 col-lg-offset-1 spacing">
-                <h4>{% firstof episode.title|upper episode|upper %}</h4>
+                <h4>{{ episode|title }}</h4>
 
                 <p>{% firstof episode.summary|safe episode.programme.synopsis|safe '' %}</p>
 

--- a/radio/apps/programmes/templates/programmes/programme_list.html
+++ b/radio/apps/programmes/templates/programmes/programme_list.html
@@ -17,7 +17,7 @@
                 </div>
 
                 <div class="col-lg-6">
-                    <h4>{{ programme.name }}</h4>
+                    <h4>{{ programme.name|title }}</h4>
                     <p>{{ programme.synopsis|truncatewords_html:130|safe }}</p>
                     <p>
                         <br/>

--- a/radio/apps/radio/templates/radio/index.html
+++ b/radio/apps/radio/templates/radio/index.html
@@ -148,7 +148,7 @@
                 <div class="hline"></div>
                 {% for episode in latest_episodes %}
                     <p>
-                        <a href="{{ episode.get_absolute_url }}">{% firstof episode.title|title episode|title %}</a>
+                        <a href="{{ episode.get_absolute_url }}">{{ episode|title }}</a>
                     </p>
                 {% empty %}
                     <p>{% trans "There are currently no podcast" %}</p>


### PR DESCRIPTION
As the model of episode creates a realy good name it has been
updated the use of the representation. Now it is always shown the
episode name if available and the name of the program if not.
