### PR TITLE
Adding podcast download button

### DIFF
--- a/radio/apps/programmes/templates/programmes/episode_detail.html
+++ b/radio/apps/programmes/templates/programmes/episode_detail.html
@@ -19,11 +19,14 @@
                 <p>{% firstof episode.summary|safe episode.programme.synopsis|safe '' %}</p>
 
                 <h4>{% trans "Podcast" %}</h4>
-                <p>
+                <p class="podcast-download">
                     {% if episode.podcast %}
                         <audio src="{{ episode.podcast.url }}" type="{{ episode.podcast.mime_type }}" controls>
                             {% trans "Your browser does not support the audio element." %}
                         </audio>
+                        <a href="{{ episode.podcast.url }}" target="_blank" download>
+                          <span class="fa fa-download fa-2x"></span>
+                        </a>
                     {% else %}
                         {% if not episode_end_date or now > episode_end_date %}
                             {% trans "Sorry, this podcast isn't available yet" %}

--- a/radio/apps/radio/static/radio/css/style.css
+++ b/radio/apps/radio/static/radio/css/style.css
@@ -496,3 +496,11 @@ csmall2 {
 	padding-right: 15px;
 	font-size: 18px;
 }
+
+p.podcast-download {
+	display: inline-flex;
+}
+
+p.podcast-download a {
+	margin-left: 10px;
+}


### PR DESCRIPTION
Using download attr of 'a' html tag. For safari or older IE versions,
target="_blank" is set, so at least a new page with audio is opened so plp can
download easily.
