### PR TITLE
Remove warning docker_compose

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
 
 

--- a/docker-compose.staging.yaml
+++ b/docker-compose.staging.yaml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
 
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
 
 


### PR DESCRIPTION
Remove warning about docker-compose.yaml 

>WARN[0000] /var/www/workspace/django-radio/docker-compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 

>WARN[0000] /var/www/workspace/django-radio/docker-compose.override.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion

Reference:

https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-optional

Issue related: https://github.com/iago1460/django-radio/issues/70